### PR TITLE
removed cancel animation frame - not required

### DIFF
--- a/js-anim.js
+++ b/js-anim.js
@@ -29,8 +29,6 @@
 
             if (progress < 1) {
                 window.requestAnimationFrame(step);
-            }else{
-                window.cancelAnimationFrame(window.requestAnimationFrame(step));
             }
         };
 


### PR DESCRIPTION
The 'else' block is not required as the function will directly exit and won't be recalled when progress >=1

Also, window.requestAnimationFrame function works like this -

```
let id = window.requestAnimationFrame(step)
window.cancelAnimationFrame(id);
```

So it won't work in this case as we are not capturing the 'id' returned by the window.animationFrame function.